### PR TITLE
I changed printf() to behave like unix printf(2) with respect to zero padding negative numbers.

### DIFF
--- a/lib/printf.js
+++ b/lib/printf.js
@@ -387,8 +387,13 @@ Formatter.prototype.formatDouble = function(token) {
 };
 Formatter.prototype.zeroPad = function(token, /*Int*/ length) {
 	length = (arguments.length == 2) ? length : token.precision;
+	var negative = false;
 	if(typeof token.arg != "string"){
 		token.arg = "" + token.arg;
+	}
+	if (token.arg.match(/^-/)) {
+		negative = true;
+		token.arg = token.arg.replace(/-/, '');
 	}
 
 	var tenless = length - 10;
@@ -397,6 +402,7 @@ Formatter.prototype.zeroPad = function(token, /*Int*/ length) {
 	}
 	var pad = length - token.arg.length;
 	token.arg = (token.rightJustify) ? token.arg + this._zeros10.substring(0, pad) : this._zeros10.substring(0, pad) + token.arg;
+	if (negative) token.arg = '-' + token.arg;
 };
 Formatter.prototype.fitField = function(token) {
 	if(token.maxWidth >= 0 && token.arg.length > token.maxWidth){

--- a/test/sprintf.js
+++ b/test/sprintf.js
@@ -25,9 +25,9 @@ module.exports = {
 		assert.eql("42", printf("%0d", 42));
 		assert.eql("-42", printf("%0d", -42));
 		assert.eql("00042", printf("%05d", 42));
-		assert.eql("00-42", printf("%05d", -42));
+		assert.eql("-00042", printf("%05d", -42));
 		assert.eql("000000000000042", printf("%015d", 42));
-		assert.eql("000000000000-42", printf("%015d", -42));
+		assert.eql("-000000000000042", printf("%015d", -42));
 	},
 	'Flag: -': function(){
 		assert.eql("42", printf("%-d", 42));


### PR DESCRIPTION
- made printf() reflect unix format(7) behavior; put the minus sign at the
  beginning of the number with zero padding after the minus sign.
- fixed the sprintf.js expresso test to reflect the output of unix printf(2).
