### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,5 @@
     "url": "https://github.com/wdavidw/node-printf.git"
   },
   "bugs": { "url": "https://github.com/wdavidw/node-printf/issues" },
-  "licenses": [{
-    "type": "BSD",
-    "url": "http://opensource.org/licenses/BSD-3-Clause"
-  }]
+  "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/
