### PR TITLE
Add TypeScript definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "Derrell Lipman <https://github.com/derrell>"
   ],
   "main": "./lib/printf",
+  "types": "./typings/printf.d.ts",
   "engines": { "node": ">= 0.9.0" },
   "directories": {
     "lib": "./lib",

--- a/typings/printf.d.ts
+++ b/typings/printf.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for printf 0.2.5
+// Project: http://www.adaltas.com/projects/node-printf
+// Definitions by: Aluísio Augusto Silva Gonçalves <https://github.com/AluisioASG>
+
+/// <reference types="node" />
+
+export = printf;
+declare function printf(format: string, ...args: any[]): string;
+declare function printf(writeStream: NodeJS.WritableStream, format: string, ...args: any[]): void;


### PR DESCRIPTION
I've been porting my projects to TypeScript and it's annoying to have the compiler warn about missing definitions.
It is generally preferred to keep definitions with the package itself, and that's the reason for this PR, but if you've rather not have it in here I can maintain it in the [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped) community repo instead.