### PR TITLE
fix missing plus sign in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ You can use the sign flag together with `%O` to enable colors in `util.inspect`:
 
 ``` javascript
 assert.eql("With colors: { bar: \u001b[33mtrue\u001b[39m, baz: \u001b[33mfalse\u001b[39m }",
-  printf('With colors: %O', {bar: true, baz: false})
+  printf('With colors: %+O', {bar: true, baz: false})
 );
 ```
 


### PR DESCRIPTION
I'm sorry I made a mistake in docs, I forgot to place "+" in `%O`. I noticed it just now.