### PR TITLE
Syntax %-26.26s (maximum output length) does not work

### DIFF
--- a/lib/printf.js
+++ b/lib/printf.js
@@ -435,7 +435,7 @@ Formatter.prototype.zeroPad = function(token, /*Int*/ length) {
 };
 Formatter.prototype.fitField = function(token) {
   if(token.maxWidth >= 0 && token.arg.length > token.maxWidth){
-    return token.arg.substring(0, token.maxWidth);
+    token.arg = token.arg.substring(0, token.maxWidth);
   }
   if(token.zeroPad){
     this.zeroPad(token, token.minWidth);


### PR DESCRIPTION
Not sure how that still exists but the maximum length is not enforced. :)

The `fitFeild` is called this way:
```js
  this.fitField(token);
  str += token.arg;
```

However, the `fitField` does not assign the `token.arg`. Instead, it returns the new value:
```js
return token.arg.substring(0, token.maxWidth);
```

which is being ignored...

Here is how I fixed it and it works (on my machine :) ).
Looking at the other similar functions looks like the `fitField` must mutate the `token.arg`:
```js
token.arg = token.arg.substring(0, token.maxWidth);
```

Sorry I haven't added any unit tests. Rushing a bit.