### PR TITLE
Better error message when a key is missing

### DIFF
--- a/lib/printf.js
+++ b/lib/printf.js
@@ -151,7 +151,7 @@ Formatter.prototype.format = function(/*mixed...*/ filler){
           }
         }
         if(typeof value == 'undefined'){
-          throw new Error('missing key ' + token.mapping);
+          throw new Error('missing key \'' + token.mapping + '\'');
         }
         token.arg = value;
       }else{


### PR DESCRIPTION
We've stumbled upon this weird exception coming from "printf" module:
> missing key reference

It got us thinking, wtf is "key reference"?

A debugging showed that our objects have property `"reference"` with `undefined` value.

This PR slightly improves the error message from `missing key reference` to `missing key 'reference'`. Using same single-quote formatting as the other error messages in this file.